### PR TITLE
Run ChiBio in a detached screen session named ChiBio under root.

### DIFF
--- a/cb.sh
+++ b/cb.sh
@@ -1,1 +1,4 @@
+# Uncomment the following line to run ChiBio in the background
+# screen -dmS ChiBio bash -c "gunicorn -b 192.168.7.2:5000 app:application"
+# Then, comment out the next line
 gunicorn -b 192.168.7.2:5000 app:application


### PR DESCRIPTION
Hi,
I made this modification to cb.sh for my convenience as I didn't have a spare lab computer on hand. I hope you find it useful. 
ChiBio will continue to run after the SSH connection is ended and USB disconnected if the controller is connected to 5V. The app at 192.168.7.2:5000 can be accessed again when the USB is reconnected. 
Best,
Will