### PR TITLE
Guard against domain errors in OD dithering

### DIFF
--- a/app.py
+++ b/app.py
@@ -1982,7 +1982,7 @@ def Zigzag(M):
     #Subsequent section is for growth estimation.
 	
     TimeSinceSwitch=iteration-sysData[M]['Zigzag']['SwitchPoint']
-    if (iteration>6 and TimeSinceSwitch>5): #The reason we wait a few minutes after starting growth is that new media may still be introduced, it takes a while for the growth to get going.
+    if (iteration>6 and TimeSinceSwitch>5 and current > 0 and last > 0): #The reason we wait a few minutes after starting growth is that new media may still be introduced, it takes a while for the growth to get going.
         dGrowthRate=(math.log(current)-math.log(last))*60.0 #Converting to units of 1/hour
         sysData[M]['GrowthRate']['current']=sysData[M]['GrowthRate']['current']*0.95 + dGrowthRate*0.05 #We are essentially implementing an online growth rate estimator with learning rate 0.05
 


### PR DESCRIPTION
When OD dithering is turned on, a very slow-growing culture can have zero (or negative) OD when the OD control function "Zigzag" is called. This triggers a domain error when calculating a fold-change since the last OD measurement, which crashes the control function. 

This fix checks whether either the current or last OD measurements were nonpositive. If either one is, it does not attempt to calculate a growth rate.