### PR TITLE
Fixes timing-based experiment thread crash

### DIFF
--- a/app.py
+++ b/app.py
@@ -1881,6 +1881,10 @@ def RegulateOD(M):
 
     if sysData[M]['Experiment']['cycles']<3:
         Pump1=0 #In first few cycles we do precisely no pumping.
+    elif len(sysData[M]['time']['record']) < 2:
+    	addTerminal(M, "Warning: Tried to calculate time elapsed with fewer than two " +\
+    				"timepoints recorded. If you see this message a lot, there may be " +\
+    				"a more serious problem.")
     else:
         ODPast=sysData[M]['OD']['record'][-1]
         timeElapsed=((sysData[M]['time']['record'][-1])-(sysData[M]['time']['record'][-2]))/60.0 #Amount of time betwix measurements in minutes
@@ -2072,6 +2076,7 @@ def runExperiment(M,placeholder):
     time.sleep(5.0) #Wait for liquid to settle.
     if (sysData[M]['Experiment']['ON']==0):
         turnEverythingOff(M)
+        sysData[M]['Experiment']['cycles']=sysData[M]['Experiment']['cycles']-1 # Cycle didn't finish, don't count it.
         addTerminal(M,'Experiment Stopped')
         return
     


### PR DESCRIPTION
Fixes a timing problem where an experiment can think it's run more than two cycles and try to calculate an elapsed time when there are fewer than two timepoints.

Bug (without patch): If you end an experiment during the 5-second sleep (near the beginning of runExperiment), then sysData[M]['experiment']['cycles'] will be incremented to 2, with no associated third timepoint added to sysData[M]['time']['record']. This causes a mismatch between the number of cycles recorded by sysData[M]['experiment']['cycles'] and len(sysData[M]['time']['records']). 

If this happens during the first two cycles of an experiment, and you then start the experiment again with OD control, this can cause an experiment-ending crash. The first time regulateOD runs when sysData[M]['experiments']['cycles'] == 3, it will think that at least two cycles have been run and try to calculate a time difference between the last two elements of sysData[M]['time']['records'], causing an unhandled array-out-of-bounds exception. 

Fix: Now when an experiment is ended after the 5-second sleep, runExperiment will decrement sysData[M]['experiment']['cycles'] before shutting down, so that the number of cycles and the number of recorded timepoints stays in sync. 

In case my diagnosis was incorrect (or there are other ways to get those two values out of sync), this patch also adds an explicit check in regulateOD before trying to calculate time differences to make sure there are at least two times to compare. 