### PR TITLE
Service

### DIFF
--- a/cb.sh
+++ b/cb.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Uncomment the following line to run ChiBio in the background
-# screen -dmS ChiBio bash -c "gunicorn -b 192.168.178.116:5000 app:application"
+# screen -dmS ChiBio bash -c "gunicorn -b 192.168.7.2:5000 app:application"
 # Then, comment out the next line
 cd /root/chibio
-gunicorn -b 192.168.178.116:5000 app:application --capture-output --log-level info --timeout 0
+gunicorn -b 192.168.7.2:5000 app:application --capture-output --log-level info --timeout 0
 

--- a/cb.sh
+++ b/cb.sh
@@ -1,4 +1,8 @@
+#!/bin/bash
+
 # Uncomment the following line to run ChiBio in the background
-# screen -dmS ChiBio bash -c "gunicorn -b 192.168.7.2:5000 app:application"
+# screen -dmS ChiBio bash -c "gunicorn -b 192.168.178.116:5000 app:application"
 # Then, comment out the next line
-gunicorn -b 192.168.7.2:5000 app:application
+cd /root/chibio
+gunicorn -b 192.168.178.116:5000 app:application --capture-output --log-level info --timeout 0
+

--- a/chibio.service
+++ b/chibio.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Chi.bio interface
+After=syslog.target network.target
+
+[Service]
+Type=simple
+ExecStart=/root/chibio/cb.sh
+StandardError=journal
+StandardOutput=journal
+StandardInput=null
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hi, thanks for putting together this system! Here's a proposed change to have the webserver and "operating system" turn on at startup, and have the various messages show up in a log using `systemd`.  Hope this can be useful! Below the commit message with details.

These changes make the ChiBio webserver start in the background as a service after the board has been turned on

The `chibio.service` must be placed in `/lib/systemd/` and enabled with the command `systemctl enable chibio.service`

The service can be stopped/started using `systemctl`:

* `systemctl start chibio.service`
* `systemctl stop chibio.service`
* `systemctl status chibio.service`

Messages that used to be printed to stdout are now fed into `systemd` and can be read with timestamps using `journalctl`:

* `journalctl -u chibio.service`
* To follow new messages: `journalctl -f -u chibio.service`

Also added `--timeout 0` to `gunicorn` as our board was sometimes shutting down the webserver mid-experiment because of a timeout; gunicorn by default has a 30 seconds timeout, with this change there is no limit